### PR TITLE
Migrate to embedded-hal 1.0 part 2

### DIFF
--- a/examples/graphics/Cargo.toml
+++ b/examples/graphics/Cargo.toml
@@ -10,12 +10,14 @@ publish = false
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
 embedded-hal = { version = "1" }
+embedded-hal-bus = "0.2"
 panic-halt = "0.2.0"
-
 pimoroni_badger2040 = "0.6"
-uc8151 = "0.2.0"
+# uc8151 = "0.3.0"
+uc8151 = { version ="0.3.0", path ="../../uc8151-rs" }
 nb = "1.0.0"
 embedded-graphics = "0.8.0"
 embedded-text = "0.7.0"
 tinybmp = "0.5.0"
 fugit = "0.3.6"
+portable-atomic = { version = "1.6.0", features = ["critical-section"] }

--- a/examples/partial_update/Cargo.toml
+++ b/examples/partial_update/Cargo.toml
@@ -10,10 +10,12 @@ publish = false
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
 embedded-hal = { version = "1" }
+embedded-hal-bus = "0.2"
+portable-atomic = { version = "1.6.0", features = ["critical-section"] }
 panic-halt = "0.2.0"
-
 pimoroni_badger2040 = "0.6"
-uc8151 = "0.2.0"
+# uc8151 = "0.3.0"
+uc8151 = { version ="0.3.0", path ="../../uc8151-rs" }
 nb = "1.0.0"
 embedded-graphics = "0.8.0"
 embedded-text = "0.7.0"

--- a/examples/partial_update/src/main.rs
+++ b/examples/partial_update/src/main.rs
@@ -8,6 +8,7 @@ use embedded_graphics::primitives::PrimitiveStyleBuilder;
 use embedded_graphics::text::Text;
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
+use embedded_hal_bus::spi::ExclusiveDevice;
 use panic_halt as _;
 
 use bsp::hal;
@@ -74,10 +75,12 @@ fn main() -> ! {
     dc.set_high().unwrap();
     cs.set_high().unwrap();
 
-    let mut display = uc8151::Uc8151::new(spi, cs, dc, busy, reset);
+    let spi_dev = ExclusiveDevice::new(spi, cs, timer.clone()).unwrap();
+
+    let mut display = uc8151::Uc8151::new(spi_dev, dc, busy, reset, timer.clone());
 
     // Initialise display. Using the default LUT speed setting
-    let _ = display.setup(&mut timer, uc8151::LUT::Internal);
+    let _ = display.setup(uc8151::LUT::Internal);
 
     let mut current = 0i32;
     let mut channel = 0;

--- a/uc8151-rs/Cargo.toml
+++ b/uc8151-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uc8151"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "no_std library for the UC8151(IL0373) e-ink display with embedded-graphics support"

--- a/uc8151-rs/src/lib.rs
+++ b/uc8151-rs/src/lib.rs
@@ -50,7 +50,7 @@ pub struct Uc8151<SPI, DC, BUSY, RESET, DELAY> {
     pub spi: SPI,
     pub dc: DC,
     pub busy: BUSY,
-    pub reset: RESET,
+    pub reset_pin: RESET,
     pub delay: DELAY,
     pub lut: LUT,
 }
@@ -77,13 +77,13 @@ where
     DELAY: DelayNs,
 {
     /// Create new UC8151 instance from the given SPI and GPIO pins
-    pub fn new(spi: SPI, dc: DC, busy: BUSY, reset: RESET, delay: DELAY) -> Self {
+    pub fn new(spi: SPI, dc: DC, busy: BUSY, reset_pin: RESET, delay: DELAY) -> Self {
         Self {
             framebuffer: [0; FRAME_BUFFER_SIZE as usize],
             spi,
             dc,
             busy,
-            reset,
+            reset_pin,
             delay,
             lut: LUT::Internal,
         }
@@ -92,13 +92,13 @@ where
     /// Enable the display controller
     pub fn enable(&mut self) {
         // Ignoring return value for set, RP2040 GPIO is infallible
-        let _ = self.reset.set_high();
+        let _ = self.reset_pin.set_high();
     }
 
     /// Disable the display controller
     pub fn disable(&mut self) {
         // Ignoring return value for set, RP2040 GPIO is infallible
-        let _ = self.reset.set_low();
+        let _ = self.reset_pin.set_low();
     }
 
     /// Returns true if the display controller is busy

--- a/uc8151-rs/src/lib.rs
+++ b/uc8151-rs/src/lib.rs
@@ -45,10 +45,9 @@ pub enum LUT {
 }
 
 /// Uc8151 driver
-pub struct Uc8151<SPI, CS, DC, BUSY, RESET, DELAY> {
+pub struct Uc8151<SPI, DC, BUSY, RESET, DELAY> {
     framebuffer: [u8; FRAME_BUFFER_SIZE as usize],
     pub spi: SPI,
-    pub cs: CS,
     pub dc: DC,
     pub busy: BUSY,
     pub reset: RESET,
@@ -69,21 +68,19 @@ pub const WIDTH: u32 = 296;
 pub const HEIGHT: u32 = 128;
 const FRAME_BUFFER_SIZE: u32 = (WIDTH * HEIGHT) / 8;
 
-impl<SPI, CS, DC, BUSY, RESET, DELAY> Uc8151<SPI, CS, DC, BUSY, RESET, DELAY>
+impl<SPI, DC, BUSY, RESET, DELAY> Uc8151<SPI, DC, BUSY, RESET, DELAY>
 where
     SPI: SpiDevice,
-    CS: OutputPin,
     DC: OutputPin,
     BUSY: InputPin,
     RESET: OutputPin,
     DELAY: DelayNs,
 {
     /// Create new UC8151 instance from the given SPI and GPIO pins
-    pub fn new(spi: SPI, cs: CS, dc: DC, busy: BUSY, reset: RESET, delay: DELAY) -> Self {
+    pub fn new(spi: SPI, dc: DC, busy: BUSY, reset: RESET, delay: DELAY) -> Self {
         Self {
             framebuffer: [0; FRAME_BUFFER_SIZE as usize],
             spi,
-            cs,
             dc,
             busy,
             reset,
@@ -155,7 +152,6 @@ where
 
     /// Send command via SPI to the display
     pub fn command(&mut self, reg: Instruction, data: &[u8]) -> Result<(), SpiDataError> {
-        let _ = self.cs.set_low();
         let _ = self.dc.set_low(); // command mode
         self.spi
             .write(&[reg as u8])
@@ -165,25 +161,19 @@ where
             let _ = self.dc.set_high(); // data mode
             self.spi.write(data).map_err(|_| SpiDataError::SpiError)?;
         }
-
-        let _ = self.cs.set_high();
         Ok(())
     }
 
     /// Send data via SPI to the display
     pub fn data(&mut self, data: &[u8]) -> Result<(), SpiDataError> {
-        let _ = self.cs.set_low();
         let _ = self.dc.set_high(); // data mode
         self.spi.write(data).map_err(|_| SpiDataError::SpiError)?;
-
-        let _ = self.cs.set_high();
         Ok(())
     }
 
     /// Send framebuffer to display via SPI.
     /// This is a low-level function, call update() if you just want to update the display
     pub fn transmit_framebuffer(&mut self) -> Result<(), SpiDataError> {
-        let _ = self.cs.set_low();
         let _ = self.dc.set_low(); // command mode
         self.spi
             .write(&[Instruction::DTM2 as u8])
@@ -193,8 +183,6 @@ where
         self.spi
             .write(&self.framebuffer)
             .map_err(|_| SpiDataError::SpiError)?;
-
-        let _ = self.cs.set_high();
         Ok(())
     }
 
@@ -206,12 +194,10 @@ where
             None => return Err(SpiDataError::SpiError),
         };
 
-        let _ = self.cs.set_low();
         let _ = self.dc.set_high(); // data mode
         self.spi
             .write(framebuffer)
             .map_err(|_| SpiDataError::SpiError)?;
-        let _ = self.cs.set_high();
         Ok(())
     }
 
@@ -381,10 +367,9 @@ where
 }
 
 #[cfg(feature = "graphics")]
-impl<SPI, CS, DC, BUSY, RESET, DELAY> DrawTarget for Uc8151<SPI, CS, DC, BUSY, RESET, DELAY>
+impl<SPI, DC, BUSY, RESET, DELAY> DrawTarget for Uc8151<SPI, DC, BUSY, RESET, DELAY>
 where
     SPI: SpiDevice,
-    CS: OutputPin,
     DC: OutputPin,
     BUSY: InputPin,
     RESET: OutputPin,
@@ -411,10 +396,9 @@ where
 }
 
 #[cfg(feature = "graphics")]
-impl<SPI, CS, DC, BUSY, RESET, DELAY> OriginDimensions for Uc8151<SPI, CS, DC, BUSY, RESET, DELAY>
+impl<SPI, DC, BUSY, RESET, DELAY> OriginDimensions for Uc8151<SPI, DC, BUSY, RESET, DELAY>
 where
     SPI: SpiDevice,
-    CS: OutputPin,
     DC: OutputPin,
     BUSY: InputPin,
     RESET: OutputPin,


### PR DESCRIPTION
Missed a few parts in #7, like CS being handled by SpiDevice, and bumping the version number.
Examples are now updated to use embedded-hal 1.0 traits.